### PR TITLE
JS Refactoring inside win.webContents.executeJavaScript

### DIFF
--- a/_server.js
+++ b/_server.js
@@ -141,90 +141,13 @@ shadowServer.on('listening', () => {
 
 function shadyThenShadowGetDOMInsidePage() {
   win.webContents.executeJavaScript(`
-    var ipcRenderer = require('electron').ipcRenderer;
-    var asyncImports = '';
-    var remote = require('electron').remote;
-    var directory = remote.getGlobal('directory');
-    var hash = require('string-hash'); 
-
-    var htmlImports = document.querySelectorAll('link[rel="import"]');
-
-    if(htmlImports.length > 0) {
-      var html = document.cloneNode(true);
-      html.querySelector('body').removeAttribute('unresolved');
-
-      var imports = html.querySelectorAll('link[rel="import"]');
-      var head = html.querySelector('head');
-      var shadowPolymerScript = document.createElement('script');
-      shadowPolymerScript.innerText = 'window.Polymer = { dom: "shadow", lazyRegister: true}';
-      head.insertBefore(shadowPolymerScript, imports[0]);
-
-      var hashString = '';
-      imports.forEach((linkNode) => {
-        asyncImports += linkNode.outerHTML;
-        hashString += linkNode['href'];
-        linkNode.parentNode.removeChild(linkNode);
-      });
-      var hashed = hash(hashString)
-      ipcRenderer.send('setAsyncImports', hashed, asyncImports);
-
-      var newImport = html.createElement('link');
-      newImport.setAttribute('rel', 'import');
-      newImport.setAttribute('href', '_asyncImport' + hashed + '.html');
-      newImport.setAttribute('async', '');
-      html.querySelector('head').appendChild(newImport);
-
-      // Make sure pathnames are relative
-      html.querySelectorAll('[url]').forEach((link) => { link.setAttribute('url', link.url.replace(directory, ''))});
-      html.querySelectorAll('[src]').forEach((link) => { link.setAttribute('src', link.src.replace(directory, ''))});
-      html.querySelectorAll('[href]').forEach((link) => { link.setAttribute('href', link.href.replace(directory, ''))});
-
-      ipcRenderer.send('receiveSerializedDOM', html.documentElement.outerHTML, false);
-    } else {
-      ipcRenderer.send('receiveSerializedDOM', document.documentElement.outerHTML, false);
-    }
+    require('./_server_execute_js')().hybridVersion();
     `);
 }
 
 function shadyGetDOMInsidePage() {
   win.webContents.executeJavaScript(`
-    var ipcRenderer = require('electron').ipcRenderer;
-    var asyncImports = '';
-    var remote = require('electron').remote;
-    var directory = remote.getGlobal('directory');
-    var hash = require('string-hash'); 
-
-    var htmlImports = document.querySelectorAll('link[rel="import"]');
-
-    if(htmlImports.length > 0) {
-      var html = document.cloneNode(true);
-      html.querySelector('body').removeAttribute('unresolved');
-
-      var hashString = '';
-      var imports = html.querySelectorAll('link[rel="import"]');
-      imports.forEach((linkNode) => {
-        asyncImports += linkNode.outerHTML;
-        hashString += linkNode['href'];
-        linkNode.parentNode.removeChild(linkNode);
-      });
-      var hashed = hash(hashString)
-      ipcRenderer.sendSync('setAsyncImports', hashed, asyncImports)
-
-      var newImport = html.createElement('link');
-      newImport.setAttribute('rel', 'import');
-      newImport.setAttribute('href', '_asyncImport' + hashed + '.html');
-      newImport.setAttribute('async', '');
-      html.querySelector('head').appendChild(newImport);
-
-      // Make sure pathnames are relative
-      html.querySelectorAll('[url]').forEach((link) => { link.setAttribute('url', link.url.replace(directory, ''))});
-      html.querySelectorAll('[src]').forEach((link) => { link.setAttribute('src', link.src.replace(directory, ''))});
-      html.querySelectorAll('[href]').forEach((link) => { link.setAttribute('href', link.href.replace(directory, ''))});
-
-      ipcRenderer.send('receiveSerializedDOM', html.documentElement.outerHTML, true);
-    } else {
-      ipcRenderer.send('receiveSerializedDOM', document.documentElement.outerHTML, true);
-    }
+    require('./_server_execute_js')().shadyVersion();
     `);
 }
 

--- a/_server_execute_js.js
+++ b/_server_execute_js.js
@@ -1,0 +1,94 @@
+module.exports = function() {
+
+  return {
+
+    hybridVersion: function() {
+      console.log("DONE")
+      var ipcRenderer = require('electron').ipcRenderer;
+      var asyncImports = '';
+      var remote = require('electron').remote;
+      var directory = remote.getGlobal('directory');
+      var hash = require('string-hash'); 
+
+      var htmlImports = document.querySelectorAll('link[rel="import"]');
+
+      if(htmlImports.length > 0) {
+        var html = document.cloneNode(true);
+        html.querySelector('body').removeAttribute('unresolved');
+
+        var imports = html.querySelectorAll('link[rel="import"]');
+        var head = html.querySelector('head');
+        var shadowPolymerScript = document.createElement('script');
+        shadowPolymerScript.innerText = 'window.Polymer = { dom: "shadow", lazyRegister: true}';
+        head.insertBefore(shadowPolymerScript, imports[0]);
+
+        var hashString = '';
+        imports.forEach((linkNode) => {
+          asyncImports += linkNode.outerHTML;
+          hashString += linkNode['href'];
+          linkNode.parentNode.removeChild(linkNode);
+        });
+        var hashed = hash(hashString)
+        ipcRenderer.send('setAsyncImports', hashed, asyncImports);
+
+        var newImport = html.createElement('link');
+        newImport.setAttribute('rel', 'import');
+        newImport.setAttribute('href', '_asyncImport' + hashed + '.html');
+        newImport.setAttribute('async', '');
+        html.querySelector('head').appendChild(newImport);
+
+        // Make sure pathnames are relative
+        html.querySelectorAll('[url]').forEach((link) => { link.setAttribute('url', link.url.replace(directory, ''))});
+        html.querySelectorAll('[src]').forEach((link) => { link.setAttribute('src', link.src.replace(directory, ''))});
+        html.querySelectorAll('[href]').forEach((link) => { link.setAttribute('href', link.href.replace(directory, ''))});
+
+        ipcRenderer.send('receiveSerializedDOM', html.documentElement.outerHTML, false);
+      } else {
+        ipcRenderer.send('receiveSerializedDOM', document.documentElement.outerHTML, false);
+      }
+    },
+
+    shadyVersion: function() {
+      var ipcRenderer = require('electron').ipcRenderer;
+      var asyncImports = '';
+      var remote = require('electron').remote;
+      var directory = remote.getGlobal('directory');
+      var hash = require('string-hash'); 
+
+      var htmlImports = document.querySelectorAll('link[rel="import"]');
+
+      if(htmlImports.length > 0) {
+        var html = document.cloneNode(true);
+        html.querySelector('body').removeAttribute('unresolved');
+
+        var hashString = '';
+        var imports = html.querySelectorAll('link[rel="import"]');
+        imports.forEach((linkNode) => {
+          asyncImports += linkNode.outerHTML;
+          hashString += linkNode['href'];
+          linkNode.parentNode.removeChild(linkNode);
+        });
+        var hashed = hash(hashString)
+        ipcRenderer.sendSync('setAsyncImports', hashed, asyncImports)
+
+        var newImport = html.createElement('link');
+        newImport.setAttribute('rel', 'import');
+        newImport.setAttribute('href', '_asyncImport' + hashed + '.html');
+        newImport.setAttribute('async', '');
+        html.querySelector('head').appendChild(newImport);
+
+        // Make sure pathnames are relative
+        html.querySelectorAll('[url]').forEach((link) => { link.setAttribute('url', link.url.replace(directory, ''))});
+        html.querySelectorAll('[src]').forEach((link) => { link.setAttribute('src', link.src.replace(directory, ''))});
+        html.querySelectorAll('[href]').forEach((link) => { link.setAttribute('href', link.href.replace(directory, ''))});
+
+        ipcRenderer.send('receiveSerializedDOM', html.documentElement.outerHTML, true);
+      } else {
+        ipcRenderer.send('receiveSerializedDOM', document.documentElement.outerHTML, true);
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Refactors the logic inside win.webContents.executeJavaScript by moving it to another file and then exporting the module.

This commit addresses @usergenic's comment in issue #15.