### PR TITLE
Shadowroot custom elem v1 workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src
 data
 index*.html
 *manifest.json
+*.class

--- a/BowerToNPM.java
+++ b/BowerToNPM.java
@@ -17,6 +17,49 @@ public class BowerToNPM {
     private static final String GREEN = "\u001B[32m";
     private static final String RESET = "\033[0;0m";
 
+    private static void convert(Path polymerPath, Path wcPath, Path oldPolymerPath, Path oldWcPath, Path directory) {
+        class BowerToNPMConverter {
+
+            private Path polymerPath;
+            private Path wcPath;
+            private Path oldPolymerPath;
+            private Path oldWcPath;
+
+            BowerToNPMConverter(Path polymerPath, Path wcPath, Path oldPolymerPath, Path oldWcPath, Path directory) {
+                this.polymerPath = polymerPath;
+                this.wcPath = wcPath;
+                this.oldPolymerPath = oldPolymerPath;
+                this.oldWcPath = oldWcPath;
+
+                rewriteFiles(directory);
+            }
+
+            private void rewriteFiles(Path directory) {
+                // TODO(namchi): Get files in directory and change path names
+                ArrayDeque<String> files = filesToRewrite(directory.toFile());
+            }
+
+            private ArrayDeque<String> filesToRewrite(File directory) {
+                ArrayDeque<String> files = new ArrayDeque<String>();
+
+                String path = "";
+                if(!directory.isDirectory() && (path = directory.getAbsolutePath()).endsWith(".html")) {
+                    files.add(path);
+                } else {
+                    for(File f: directory.listFiles()) {
+                        if(f.isFile() && (path = f.getAbsolutePath()).endsWith(".html")) {
+                            files.add(path);
+                        } else if(f.isDirectory()) {
+                            files.addAll(filesToRewrite(f));
+                        }
+                    }
+                }
+
+                return files;
+            }
+        }
+        BowerToNPMConverter converter = new BowerToNPMConverter(polymerPath, wcPath, oldPolymerPath, oldWcPath, directory);
+    }
 
     private static Path checkPath(String path) {
         if(!new File(path).exists()) {
@@ -29,19 +72,39 @@ public class BowerToNPM {
 
     public static void main(String[] args) {
         Scanner in = new Scanner(System.in);
+        String input = "";
 
-        System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "new Polymer directory: " + RESET + GREEN);
-        String polymerDir = in.next();
+        // node_modules/@polymer/polymer/polymer.html
+        System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "NEW Polymer file: " + RESET + GREEN);
+        input = in.next();
         System.out.print(RESET);
-        Path polymerPath = checkPath(polymerDir);
+        Path polymerPath = checkPath(input);
 
-        // System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "directory or file to convert" + RESET + BLUE + ": " + RESET + GREEN);
-        // String otherDir = in.next();
-        // System.out.print(RESET);
-        // Path otherPath = checkPath(otherDir);
+        // node_modules/@polymer/polymer/node_modules/webcomponents.js/webcomponents-lite.js
+        System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "NEW webcomponents.js file: " + RESET + GREEN);
+        input = in.next();
+        System.out.print(RESET);
+        Path wcPath = checkPath(input);
 
-        // System.out.println(otherPath.relativize(polymerPath));
-        //System.out.println(new File(bowerDir).toURI().relativize(new File(otherDir).toURI()).getPath());
+        // bower_components/polymer/polymer.html
+        System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "OLD Polymer file: " + RESET + GREEN);
+        input = in.next();
+        System.out.print(RESET);
+        Path oldPolymerPath = checkPath(input);
+
+        // bower_components/webcomponentsjs/webcomponents-lite.js
+        System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "OLD webcomponents.js file: " + RESET + GREEN);
+        input = in.next();
+        System.out.print(RESET);
+        Path oldWcPath = checkPath(input);
+
+        // bower_components/
+        System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "directory or file to convert: " + RESET + GREEN);
+        input = in.next();
+        System.out.print(RESET);
+        Path directory = checkPath(input);
+
+        convert(polymerPath, wcPath, oldPolymerPath, oldWcPath, directory);
     }
 
 }

--- a/BowerToNPM.java
+++ b/BowerToNPM.java
@@ -1,0 +1,47 @@
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.StringBuilder;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.Scanner;
+
+public class BowerToNPM {
+
+    private static final String BLUE = "\u001B[34m";
+    private static final String BOLD = "\033[0;1m";
+    private static final String GREEN = "\u001B[32m";
+    private static final String RESET = "\033[0;0m";
+
+
+    private static Path checkPath(String path) {
+        if(!new File(path).exists()) {
+            System.err.println("Invalid path: " + path);
+            System.exit(1);
+        }
+        
+        return Paths.get(path);
+    }
+
+    public static void main(String[] args) {
+        Scanner in = new Scanner(System.in);
+
+        System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "new Polymer directory: " + RESET + GREEN);
+        String polymerDir = in.next();
+        System.out.print(RESET);
+        Path polymerPath = checkPath(polymerDir);
+
+        // System.out.print(RESET + BLUE + "Path to " + RESET + BOLD + "directory or file to convert" + RESET + BLUE + ": " + RESET + GREEN);
+        // String otherDir = in.next();
+        // System.out.print(RESET);
+        // Path otherPath = checkPath(otherDir);
+
+        // System.out.println(otherPath.relativize(polymerPath));
+        //System.out.println(new File(bowerDir).toURI().relativize(new File(otherDir).toURI()).getPath());
+    }
+
+}

--- a/BowerToNPMDefaultInputs.txt
+++ b/BowerToNPMDefaultInputs.txt
@@ -1,0 +1,5 @@
+node_modules/@polymer/polymer/polymer.html
+node_modules/@polymer/polymer/node_modules/webcomponents.js/webcomponents-lite.js
+bower_components/polymer/polymer.html
+bower_components/webcomponentsjs/webcomponents-lite.js
+bower_components


### PR DESCRIPTION
Wrote a Java class to do bower-to-npm filepath conversions. This change is a response to Issue#25, which is to modify the server with the Custom Elements v1 spec in mind (i.e. no multiple shadow roots). The fix involves:

1. Modifying Polymer#1.0 element registration to reuse shadow roots instead of attaching multiple shadow roots, and then using npm to link the modified library.
2. Rewriting filepaths of bower's polymer.html and webcomponents.js to npm's corresponding files because bower and npm do not play well together.

This PR addresses part 2. The fix to part 1 will come later.